### PR TITLE
Support of configuration for multi-installations

### DIFF
--- a/OpenNFT.py
+++ b/OpenNFT.py
@@ -15,7 +15,7 @@ based on activity, connectivity and multivariate pattern analysis. Neuroimage 15
 Real-time fMRI data for testing OpenNFT functionality. Data in Brief 14:344-347.
 
 _________________________________________________________________________
-Copyright (C) 2016-2017 OpenNFT.org
+Copyright (C) 2016-2019 OpenNFT.org
 
 License
 OpenNFT Software is open-source and is distributed under GNU GPL v3.0 license
@@ -100,6 +100,7 @@ class CreateFileEventHandler(FileSystemEventHandler):
             self.recorder.recordEvent(Times.t1, 0)
             self.fq.put(event.src_path)
 
+
 class ViewBoxWithoutPadding(pg.ViewBox):
     def suggestPadding(self, axis):
         return 0.0
@@ -121,7 +122,6 @@ class OpenNFT(QWidget):
         #self.printToLog(data)
         data = bytes(data, 'UTF-8')
         self.udpSender.sendto(data, (config.UDP_IP, config.UDP_PORT))
-
 
     # --------------------------------------------------------------------------
     def finalizeUdpSender(self):
@@ -167,7 +167,8 @@ class OpenNFT(QWidget):
          self.normRoiPlot) = self.createRoiPlots()
 
         self.settingFileName = config.ROOT_PATH
-        self.appSettings = QSettings(self)
+        self.appSettings = QSettings(
+            str(utils.get_app_settings_file()), QSettings.IniFormat, self)
 
         self.iteration = 1
         self.preiteration = 0
@@ -1202,7 +1203,7 @@ class OpenNFT(QWidget):
         self.leSetFile.setText(fname)
         self.P['SetFile'] = fname
 
-        self.settings = QSettings(fname, QSettings.IniFormat)
+        self.settings = QSettings(fname, QSettings.IniFormat, self)
         self.loadSettingsFromSetFile()
 
         self.btnSetup.setEnabled(True)
@@ -1925,7 +1926,8 @@ class OpenNFT(QWidget):
             self.t1.join()  # ns.ptb.display(displayData)
 
         return
-# --------------------------------------------------------------------------
+
+
 def main():
     app = QApplication(sys.argv)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+numpy>=1.15.0
+PyQt5>=5.12.0
+pyqtgraph>=0.10.0
+watchdog>=0.9.0
+pywin32>=224
+pyHook>=1.5.1

--- a/utils.py
+++ b/utils.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 """
 __________________________________________________________________________
-Copyright (C) 2016-2017 OpenNFT.org
+Copyright (C) 2016-2019 OpenNFT.org
 
 Written by Evgeny Prilepin
 
@@ -9,11 +9,17 @@ Written by Evgeny Prilepin
 
 import time
 import contextlib
+import pathlib
+import hashlib
+import random
+import uuid
 
 import numpy as np
+from PyQt5 import QtCore, QtWidgets
+
+import config
 
 
-# ==============================================================================
 @contextlib.contextmanager
 def timeit(message):
     t = time.time()
@@ -32,7 +38,6 @@ def timeit(message):
     print(message + ' {:.2f} {}'.format(to, units))
 
 
-# ==============================================================================
 def generate_random_number_string(num=5):
     """Generates a sequence of numbers and returns it as string
     """
@@ -40,3 +45,48 @@ def generate_random_number_string(num=5):
     s_num = ''.join(map(str, num))
 
     return s_num
+
+
+def get_app_instance_dir() -> pathlib.Path:
+    """Returns application instance directory
+
+    :return: A full path to instance directory
+    """
+    return pathlib.Path(config.ROOT_PATH)
+
+
+def get_unique_app_instance_uuid() -> str:
+    """Returns unique application instance uuid
+
+    :return: Unique application instance uuid that depends from application instance directory
+    """
+    inst_dir = get_app_instance_dir()
+
+    sha1 = hashlib.sha1()
+    sha1.update(str(inst_dir).encode('utf-8'))
+    inst_hash = sha1.hexdigest()
+
+    random_state = random.getstate()
+    random.seed(inst_hash)
+    u = str(uuid.UUID(int=random.getrandbits(128)))
+    random.setstate(random_state)
+
+    return u
+
+
+def get_app_config_dir() -> pathlib.Path:
+    """Returns application configuration directory
+
+    :return: A full path to application configuration directory
+    """
+    return pathlib.Path(QtCore.QStandardPaths.standardLocations(
+        QtCore.QStandardPaths.AppConfigLocation)[0]) / get_unique_app_instance_uuid()
+
+
+def get_app_settings_file() -> pathlib.Path:
+    """Returns a path to application settings file
+
+    :return: A full path to application settings INI-file
+    """
+    app_name = QtWidgets.QApplication.applicationName()
+    return get_app_config_dir() / (app_name + '.ini')


### PR DESCRIPTION
This PR adds support of configuration for multi-installations (#11).

Now the application settings will be store to INI-file in the unique settings folder like this:
```
c:\Users\espdev\AppData\Local\OpenNFT\OpenNFT\189fccf5-f0f6-0313-1022-106cdc949320\
```
Where `189fccf5-f0f6-0313-1022-106cdc949320` is unique UUID for app instance (app installation directory).
