### PR TITLE
Elevate privileges for installing Matlab Engine for Python

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,8 +34,8 @@ You can check installation result using `-v` (verbose) option:
 ```
 
 **NOTE**: 
-If you use Windows and MATLAB has been installed to default direcory (Program Files) you need 
-Administrator rights for installing Matlab Engine for Python (You need to install OpenNFT via pip as Administrator).
+If you do not have write access in MATLABROOT the installer will try to install "Matlab Engine for Python" 
+with Administrator/root privileges (It elevate privileges via UAC/sudo).
 
 Also you can install OpenNFT from your working directory (OpenNFT project root directory):
 

--- a/install_matlabengine.py
+++ b/install_matlabengine.py
@@ -1,0 +1,48 @@
+# -*- coding: utf-8 -*-
+
+import sys
+import os
+import subprocess
+
+sys.path = sys.argv[3:]
+
+import elevate
+import chardet
+
+
+def main():
+    engine_dir = sys.argv[1]
+    ferr = sys.argv[2]
+
+    engine_setup = os.path.join(engine_dir, 'setup.py')
+    install_command = [sys.executable, engine_setup, 'install']
+
+    p = subprocess.run(install_command,
+                       stdout=subprocess.PIPE,
+                       stderr=subprocess.PIPE,
+                       cwd=engine_dir)
+
+    if p.returncode != 0:
+        if (b"error: could not create 'build'" in p.stderr
+                or b"error: You do not have write permission" in p.stderr):
+            # Access denied, try to install as Administrator/root
+            elevate.elevate(show_console=False, graphical=True)
+
+        try:
+            stderr_text = p.stderr.decode()
+        except UnicodeDecodeError:
+            enc = chardet.detect(p.stderr)['encoding']
+            if enc:
+                stderr_text = p.stderr.decode(enc)
+            else:
+                # cannot decode bytes, return as it is
+                stderr_text = str(p.stderr)
+
+        with open(ferr, 'w', encoding='utf-8') as fp:
+            fp.write(stderr_text)
+
+    return p.returncode
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,4 @@
 [options]
 setup_requires =
     chardet
+    elevate

--- a/setup.py
+++ b/setup.py
@@ -126,7 +126,7 @@ class InstallMatlabEngineMixin:
         install_script = str(ROOT_DIR / 'install_matlabengine.py')
         install_command = [sys.executable, install_script, str(engine_dir), ferr_name] + sys.path
 
-        p = subprocess.run(install_command, cwd=str(ROOT_DIR))
+        p = subprocess.run(install_command)
 
         with open(ferr_name, 'r', encoding='utf-8') as ferr:
             stderr_text = ferr.read()

--- a/setup.py
+++ b/setup.py
@@ -177,6 +177,7 @@ class DevelopCommand(develop, InstallMatlabEngineMixin):
         self._install_matlab_engine()
         develop.run(self)
 
+
 setup(
     name=NAME,
     version=get_version(),


### PR DESCRIPTION
If we do not have write access in `MATLABROOT` we try to install "Matlab Engine for Python" 
with Administrator/root privileges (It elevate privileges via UAC/sudo).

