### PR TITLE
Correct dispValue computation

### DIFF
--- a/opennft/matlab/ValDec
+++ b/opennft/matlab/ValDec
@@ -65,7 +65,7 @@ if isPSC && (strcmp(P.Prot, 'Cont') || strcmp(P.Prot, 'ContTask'))
 
         % compute average %SC feedback value
         tmp_fbVal = eval(P.RoiAnatOperation); 
-        dispValue = round(P.MaxFeedbackVal*10^P.FeedbackValDec * tmp_fbVal) /10^P.FeedbackValDec; 
+        dispValue = round(10^P.FeedbackValDec * tmp_fbVal);
 
         % [0...P.MaxFeedbackVal], for Display
         if ~P.NegFeedback && dispValue < 0
@@ -142,7 +142,7 @@ if isPSC && strcmp(P.Prot, 'Inter')
             % compute average %SC feedback value
             tmp_fbVal = eval(P.RoiAnatOperation); 
             mainLoopData.vectNFBs(indVolNorm) = tmp_fbVal;
-            dispValue = round(P.MaxFeedbackVal*10^P.FeedbackValDec * tmp_fbVal) /10^P.FeedbackValDec; 
+            dispValue = round(10^P.FeedbackValDec * tmp_fbVal); 
 
             % [0...P.MaxFeedbackVal], for Display
             if ~P.NegFeedback && dispValue < 0
@@ -225,7 +225,7 @@ if isDCM
         mainLoopData.vectNFBs(indNFTrial) = logBF;
         mainLoopData.flagEndDCM = 1;
         tmp_fbVal = mainLoopData.logBF(indNFTrial);
-        mainLoopData.dispValue = round(P.MaxFeedbackVal*10^P.FeedbackValDec * tmp_fbVal) /10^P.FeedbackValDec; 
+        mainLoopData.dispValue = round(10^P.FeedbackValDec * tmp_fbVal);
 
         % calculating monetory reward value
         if mainLoopData.dispValue > thReward
@@ -268,7 +268,7 @@ if isSVM
 
         % compute average feedback value
         tmp_fbVal = eval(P.RoiAnatOperation); 
-        dispValue = round(P.MaxFeedbackVal*10^P.FeedbackValDec * tmp_fbVal) /10^P.FeedbackValDec; 
+        dispValue = round(10^P.FeedbackValDec * tmp_fbVal); 
 
         mainLoopData.norm_percValues(indVolNorm,:) = norm_percValues;
         mainLoopData.dispValues(indVolNorm) = dispValue;


### PR DESCRIPTION
In the previous version, the formula maxVal *10^ValDec *tmpvalue / 10^ValDec does not make sense because 10^ValDec would cancel out anyway (round does not change this). Also, I believe in this calculation the maximum value should not appear, as it is only relevant for thresholding later.