### PR TITLE
Allow for non quadratic images

### DIFF
--- a/opennft/matlab/utils/vol3Dimg2D.m
+++ b/opennft/matlab/utils/vol3Dimg2D.m
@@ -23,7 +23,7 @@ for sy  = 0:slNrImg2DdimY-1
     for sx = 0:slNrImg2DdimX-1
         sl = sl+1;
         if sl > dim3D(3), break, else
-            img2D(sy*dim3D(1) + 1:(sy+1)*dim3D(1), ...
+            img2D(sy*dim3D(2) + 1:(sy+1)*dim3D(2), ...
                   sx*dim3D(1) + 1:(sx+1)*dim3D(1)) = rot90(vol3D(:,:,sl));
         end
     end


### PR DESCRIPTION
We tried to use non-quadratic scans and encountered problems in vol3Dimg2D and getMosaicDim. The mosaic is constructed in a way that only uses the first image dimension. However, this can be changed straightforwardly by using the second axis of the scan in the mosaic.