### PR TITLE
Add FeedbackValDec to P passed to displayFeedback

### DIFF
--- a/opennft/opennft.py
+++ b/opennft/opennft.py
@@ -1139,6 +1139,7 @@ class OpenNFT(QWidget):
                     ptbP['WorkFolder'] = self.P['WorkFolder']
                     ptbP['DisplayFeedbackFullscreen'] = self.P['DisplayFeedbackFullscreen']
                     ptbP['Prot'] = self.P['Prot']
+                    ptbP['FeedbackValDec'] = self.P['FeedbackValDec']
                     if self.P['Prot'] == 'ContTask':
                         ptbP['TaskFolder'] = self.P['TaskFolder']
 


### PR DESCRIPTION
In the nfbDispl/displayFeedback file, the dispValue is used which is computed in the file nfbCalc. To allow for more flexible processing of this value in displayFeedback, it was useful for us to include the field 'FeedbackValDec' in the struct P that is passed to displayFeedback.