### PR TITLE
Update opennft.ui

### DIFF
--- a/opennft/ui/opennft.ui
+++ b/opennft/ui/opennft.ui
@@ -1266,6 +1266,29 @@
                                                 </property>
                                             </widget>
                                         </item>
+					<item>
+                                            <widget class="QLabel" name="label_41_3">
+                                                <property name="text">
+                                                    <string>Minimum Feedback Value</string>
+                                                </property>
+                                            </widget>
+                                        </item>
+                                        <item>
+                                            <widget class="QLineEdit" name="leMinFeedbackVal">
+                                                <property name="maximumSize">
+                                                    <size>
+                                                        <width>50</width>
+                                                        <height>20</height>
+                                                    </size>
+                                                </property>
+                                                <property name="text">
+                                                    <string>-100</string>
+                                                </property>
+                                                <property name="readOnly">
+                                                    <bool>false</bool>
+                                                </property>
+                                            </widget>
+                                        </item>
                                         <item>
                                             <widget class="QLabel" name="label_41_2">
                                                 <property name="text">


### PR DESCRIPTION
Since now there is a checkbox "allow for negative feedback" in the UI,  there should also be some cut off for negative values (in nfbCalc.m file). Either you simply use if dispValue< - P.MaxFeedbackVal, or you give the user the option to set the minimum and maximum differently and include a new field for the Minimum Feedback Value in the UI as suggested here.