### PR TITLE
Patch 9

### DIFF
--- a/opennft/matlab/nfbCalc.m
+++ b/opennft/matlab/nfbCalc.m
@@ -70,6 +70,8 @@ if isPSC && (strcmp(P.Prot, 'Cont') || strcmp(P.Prot, 'ContTask'))
         % [0...P.MaxFeedbackVal], for Display
         if ~P.NegFeedback && dispValue < 0
             dispValue = 0;
+        elseif P.NegFeedback && dispValue < P.MinFeedbackVal
+             dispValue = P.MinFeedbackVal;
         end
         if dispValue > P.MaxFeedbackVal
             dispValue = P.MaxFeedbackVal;
@@ -147,6 +149,8 @@ if isPSC && strcmp(P.Prot, 'Inter')
             % [0...P.MaxFeedbackVal], for Display
             if ~P.NegFeedback && dispValue < 0
                 dispValue = 0;
+            elseif P.NegFeedback && dispValue < P.MinFeedbackVal
+                dispValue = P.MinFeedbackVal;
             end
             if dispValue > P.MaxFeedbackVal
                 dispValue = P.MaxFeedbackVal;

--- a/opennft/opennft.py
+++ b/opennft/opennft.py
@@ -1415,6 +1415,7 @@ class OpenNFT(QWidget):
             self.leTCPDataPort.setText(str( self.settings.value('TCPDataPort', '')))
 
         self.leMaxFeedbackVal.setText(str(self.settings.value('MaxFeedbackVal', '100')))  # FixMe
+        self.leMinFeedbackVal.setText(str(self.settings.value('MinFeedbackVal', '-100')))
         self.sbFeedbackValDec.setValue(int(self.settings.value('FeedbackValDec', '0')))     # FixMe
         self.cbNegFeedback.setChecked(str(self.settings.value('NegFeedback', 'false')).lower() == 'true')
 
@@ -1518,6 +1519,7 @@ class OpenNFT(QWidget):
             self.P['TaskFolder'] = self.leTaskFolder.text()
         
         self.P['MaxFeedbackVal'] = float( self.leMaxFeedbackVal.text())
+        self.P['MinFeedbackVal'] = float( self.leMinFeedbackVal.text())
         self.P['FeedbackValDec'] = self.sbFeedbackValDec.value()
         self.P['NegFeedback'] = self.cbNegFeedback.isChecked()
 
@@ -1601,7 +1603,8 @@ class OpenNFT(QWidget):
             self.settings.setValue('TCPDataIP', self.leTCPDataIP.text())
             self.settings.setValue('TCPDataPort', int( self.leTCPDataPort.text()))
 
-        self.settings.setValue('MaxFeedbackVal', self.P['MaxFeedbackVal'])        
+        self.settings.setValue('MaxFeedbackVal', self.P['MaxFeedbackVal'])
+        self.settings.setValue('MinFeedbackVal', self.P['MinFeedbackVal'])
         self.settings.setValue('FeedbackValDec', self.P['FeedbackValDec'])        
         self.settings.setValue('NegFeedback', self.P['NegFeedback'])
 

--- a/opennft/ui/opennft.ui
+++ b/opennft/ui/opennft.ui
@@ -1266,6 +1266,29 @@
                                                 </property>
                                             </widget>
                                         </item>
+					<item>
+                                            <widget class="QLabel" name="label_41_3">
+                                                <property name="text">
+                                                    <string>Minimum Feedback Value</string>
+                                                </property>
+                                            </widget>
+                                        </item>
+                                        <item>
+                                            <widget class="QLineEdit" name="leMinFeedbackVal">
+                                                <property name="maximumSize">
+                                                    <size>
+                                                        <width>50</width>
+                                                        <height>20</height>
+                                                    </size>
+                                                </property>
+                                                <property name="text">
+                                                    <string>-100</string>
+                                                </property>
+                                                <property name="readOnly">
+                                                    <bool>false</bool>
+                                                </property>
+                                            </widget>
+                                        </item>
                                         <item>
                                             <widget class="QLabel" name="label_41_2">
                                                 <property name="text">


### PR DESCRIPTION
Since there is an option in the UI to allow for negative feedback values, I believe there must also be a cutoff for negative values. The simplest way would be to use the negative version of the threshold for positive values (adding if P.NegFeedback && dispValue < - P.MaxFeedbackVal then dispValue =- P.MaxFeedbackVal).
Here, I suggest a different option that allows for more options for the user. If there is a separate field for the minimum feedback value in the UI, then the user could also specify a different cutoff for negative than for positive feedback values. This is simple to include in the framework because it is just processed the same way as P.MaxFeedbackVal and does not interfere with anything else. We have tested it in our version and it works well.