### PR TITLE
Add option for reading contrast from json file

### DIFF
--- a/opennft/matlab/setupProcParams.m
+++ b/opennft/matlab/setupProcParams.m
@@ -196,8 +196,8 @@ if isSVM && strcmp(P.Prot, 'Cont')
     mainLoopData.tContr = [1];
 end
 
-if isfield(P, "contrast")
-    mainLoopData.tContr = (P.contrast)';
+if isfield(P, "Contrast")
+    mainLoopData.tContr = (P.Contrast)';
     disp("Contrast was set according to json file");
 end
 %% High-pass filter for iGLM given by SPM

--- a/opennft/matlab/setupProcParams.m
+++ b/opennft/matlab/setupProcParams.m
@@ -196,6 +196,10 @@ if isSVM && strcmp(P.Prot, 'Cont')
     mainLoopData.tContr = [1];
 end
 
+if isfield(P, "contrast")
+    mainLoopData.tContr = (P.contrast)';
+    disp("Contrast was set according to json file");
+end
 %% High-pass filter for iGLM given by SPM
 mainLoopData.K = SPM.xX.K;
 

--- a/opennft/matlab/utils/loadProtocolData.m
+++ b/opennft/matlab/utils/loadProtocolData.m
@@ -22,8 +22,8 @@ nrSkipVol = P.nrSkipVol;
 
 prt = loadjson(jsonFile);
 
-if isfield(prt, "contrast");
-    P.contrast = prt.contrast;
+if isfield(prt, "Contrast");
+    P.Contrast = prt.Contrast;
 end
 
 P.BaselineName = prt.BaselineName;

--- a/opennft/matlab/utils/loadProtocolData.m
+++ b/opennft/matlab/utils/loadProtocolData.m
@@ -22,6 +22,10 @@ nrSkipVol = P.nrSkipVol;
 
 prt = loadjson(jsonFile);
 
+if isfield(prt, "contrast");
+    P.contrast = prt.contrast;
+end
+
 P.BaselineName = prt.BaselineName;
 P.CondName = prt.CondName;
 


### PR DESCRIPTION
We often had trouble because the contrast was not correct, leading to some dimension error in preprVol in the end. I think it would be better to specify the contrast in the json file, because it is a parameter that is dependent on the paradigm.
I edited the related files accordingly. Here, I put a condition checking if the field exists in the json file, to make sure that the software still works if the json file does not contain the contrast.
Of course feel free to change names of the parameters etc.