### PR TITLE
Modifications necessary to read dcm definition from protocol file

### DIFF
--- a/opennft/configs/NF_DCM_1060.json
+++ b/opennft/configs/NF_DCM_1060.json
@@ -1,4 +1,50 @@
 {
+
+	"dcmdef": {
+
+        "target": {
+
+        "a": [[1,0,1], 
+			  [0,1,1],
+			  [1,1,1]],
+
+        "b": [[0,0,1],
+			  [0,0,1],
+			  [0,0,0]],          
+
+        "c": [0,0,1],
+
+        "d": []
+                 },
+
+        "opposed": {
+
+		"a": [[1,0,1], 
+			  [0,1,1],
+			  [1,1,1]],
+
+		"b": [[0,0,0],
+		      [0,0,0],
+		      [1,1,0]],              
+
+            "c": [1,1,0],
+
+            "d": []
+                },
+        
+        "roiNames": ["AMG-L","AMG-R","PFC"],
+
+        "options": {
+            "two_state": 0,
+            "stochastic": 0,
+            "nograph": 1,
+			"centre": 1,
+			"nonlinear": 0
+        }
+
+	},
+
+
 	"BaselineName": "N",
 	"CondName": "P",
 	"RestName": "REST",

--- a/opennft/matlab/nfbDCM/dcmBegin.m
+++ b/opennft/matlab/nfbDCM/dcmBegin.m
@@ -1,90 +1,80 @@
 function calculateDcm = dcmBegin(indVol)
-% Function to add data vectors and regressors to DCM models in the
-% beginning of the DCM estimation.
-%
-% input:
-% indVol - volume(scan) index
-%
-% output:
-% dcmInputData - final DCM models structure that contains the set of
-%                parameters to estimate both models.
-%__________________________________________________________________________
-% Copyright (C) 2016-2019 OpenNFT.org
-%
-% Written by Yury Koush
-
-calculateDcm = false;
-
-P = evalin('base', 'P');
-mainLoopData = evalin('base', 'mainLoopData');
-
-if indVol <= P.nrSkipVol
-    return
-end
-
-indVolNorm = mainLoopData.indVolNorm;
-
-if ~mainLoopData.flagEndDCM
+    % Function to add data vectors and regressors to DCM models in the
+    % beginning of the DCM estimation.
+    %
+    % input:
+    % indVol - volume(scan) index
+    %
+    % output:
+    % dcmInputData - final DCM models structure that contains the set of
+    %                parameters to estimate both models.
+    %__________________________________________________________________________
+    % Copyright (C) 2016-2019 OpenNFT.org
+    %
+    % Written by Yury Koush
     
-    calculateDcm = ~isempty(find(P.endDCMblock == (indVol-P.nrSkipVol),1));
+    calculateDcm = false;
     
-    if calculateDcm
-        
-        DCM_EN = mainLoopData.DCM_EN;
-        
-        lTrial = P.lengthDCMTrial;
-        trialOffset     = lTrial - 1;
-        vectDcmTrial    = indVolNorm - trialOffset : indVolNorm;
-        
-        % set regressors
-        if ~P.fRegrDcm
-            % adding constant, the rest is left to signal processing
-            DCM_EN.Y.X0 = ones(lTrial, 1);
-        else
-            % For DCM feedback, signal processing is just Kalman filter
-            % despiking and low-pass filtering. Here we can add motion
-            % regressors, linear trend and constant
-            DCM_EN.Y.X0 = [zscore(P.motCorrParam(vectDcmTrial, :)) ...
-                zscore([1:lTrial]') ones(lTrial, 1)];
-        end
-        
-        % set time-series
-        tmp_xY.name  = 'AMG_L';
-        tmp_xY.u     = mainLoopData.kalmanProcTimeSeries(1, vectDcmTrial)';
-        tmp_xY.Sess  = 1;
-        tmp.xY(1)    = tmp_xY;
-        tmp_xY.name  = 'AMG_R';
-        tmp_xY.u     = mainLoopData.kalmanProcTimeSeries(2, vectDcmTrial)';
-        tmp_xY.Sess  = 1;
-        tmp.xY(2)    = tmp_xY;
-        tmp_xY.name  = 'PFC';
-        tmp_xY.u     = mainLoopData.kalmanProcTimeSeries(3, vectDcmTrial)';
-        tmp_xY.Sess  = 1;
-        tmp.xY(3)    = tmp_xY;
-        
-        DCM_EN.v     = length(tmp_xY.u);
-        DCM_EN.Y.Q   = spm_Ce(ones(1, DCM_EN.n) * DCM_EN.v);
-        DCM_EN.xY    = tmp.xY;
-        
-        % input
-        for i = 1:DCM_EN.n
-            DCM_EN.Y.y(:,i)  = DCM_EN.xY(i).u;
-            DCM_EN.Y.name{i} = DCM_EN.xY(i).name;
-        end
-        
-        P.indNFTrial = P.indNFTrial + 1;
-        
-        dcmInputData.DCM_EN = DCM_EN;
-        dcmInputData.dcmParTag = mainLoopData.dcmParTag;
-        dcmInputData.dcmParOpp = mainLoopData.dcmParOpp;
-        
-        % For now, this storage is a simplification of the proble that
-        % dcmInputData structure contains Python-unsupported data type
-        % that returne from MATLAB.
-        save([tempdir, 'dcmInputData.mat'], 'dcmInputData');
+    P = evalin('base', 'P');
+    mainLoopData = evalin('base', 'mainLoopData');
+    
+    if indVol <= P.nrSkipVol
+        return
     end
     
-    assignin('base', 'mainLoopData', mainLoopData);
-    assignin('base', 'P', P);
-end
-
+    indVolNorm = mainLoopData.indVolNorm;
+    
+    if ~mainLoopData.flagEndDCM
+        
+        calculateDcm = ~isempty(find(P.endDCMblock == (indVol-P.nrSkipVol),1));
+        
+        if calculateDcm
+            
+            DCM_EN = mainLoopData.DCM_EN;
+            
+            lTrial = P.lengthDCMTrial;
+            trialOffset     = lTrial - 1;
+            vectDcmTrial    = indVolNorm - trialOffset : indVolNorm;
+            
+            % set regressors
+            if ~P.fRegrDcm
+                % adding constant, the rest is left to signal processing
+                DCM_EN.Y.X0 = ones(lTrial, 1);
+            else
+                % For DCM feedback, signal processing is just Kalman filter
+                % despiking and low-pass filtering. Here we can add motion
+                % regressors, linear trend and constant
+                DCM_EN.Y.X0 = [zscore(P.motCorrParam(vectDcmTrial, :)) ...
+                    zscore([1:lTrial]') ones(lTrial, 1)];
+            end
+            
+            % Make time-series setting dynamic
+            for roi = 1:DCM_EN.n 
+                tmp.xY(roi).name   = DCM_EN.roiNames{roi};
+                DCM_EN.Y.name{roi} = DCM_EN.roiNames{roi};
+                tmp.xY(roi).u      = mainLoopData.kalmanProcTimeSeries(roi, vectDcmTrial)';
+                DCM_EN.Y.y(:,roi)  = mainLoopData.kalmanProcTimeSeries(roi, vectDcmTrial)';
+                tmp.xY(roi).Sess   = 1;
+            end
+            
+            DCM_EN.v     = length(tmp.xY(1).u);
+            DCM_EN.Y.Q   = spm_Ce(ones(1, DCM_EN.n) * DCM_EN.v);
+            DCM_EN.xY    = tmp.xY;
+            
+            P.indNFTrial = P.indNFTrial + 1;
+            
+            dcmInputData.DCM_EN = DCM_EN;
+            dcmInputData.dcmParTag = mainLoopData.dcmParTag;
+            dcmInputData.dcmParOpp = mainLoopData.dcmParOpp;
+            
+            % For now, this storage is a simplification of the proble that
+            % dcmInputData structure contains Python-unsupported data type
+            % that returne from MATLAB.
+            save([tempdir, 'dcmInputData.mat'], 'dcmInputData');
+        end
+        
+        assignin('base', 'mainLoopData', mainLoopData);
+        assignin('base', 'P', P);
+    end
+    
+    

--- a/opennft/matlab/nfbDCM/dcmPrep.m
+++ b/opennft/matlab/nfbDCM/dcmPrep.m
@@ -1,49 +1,44 @@
 function [DCM_EN, dcmParTag, dcmParOpp] = dcmPrep(SPM)
-% Function to prepare initial DCM structure from hrad-coded paprameters
-% and SPM structure.
-%
-% input:
-% SPM - SPM structure
-%
-% output:
-% DCM_EN    - initial DCM structure
-% dcmParTag - model-defining structure for a target model (model 1)
-% dcmParOpp - model-defining structure for an opposed model (model 2)
-%__________________________________________________________________________
-% Copyright (C) 2016-2019 OpenNFT.org
-%
-% Written by Yury Koush
-
-%% define structure/network
-dcmParTag.tdcmName      = ['DCM_MTag_' date];
-dcm.a         = [1 0 1; 0 1 1; 1 1 1];
-dcm.b         = [0 0 1; 0 0 1; 0 0 0];
-dcm.c         = [0; 0; 1];
-dcmParTag.dcm = dcm;
-
-dcmParOpp.tdcmName      = ['DCM_MOpp_' date];
-dcm.a         = [1 0 1; 0 1 1; 1 1 1];
-dcm.b         = [0 0 0; 0 0 0; 1 1 0];
-dcm.c         = [1; 1; 0];
-dcmParOpp.dcm = dcm;
-
-%% Settings, SPM settings, condition definition
-DCM_EN.options.nonlinear  = 0;
-DCM_EN.options.two_state  = 0;
-DCM_EN.options.stochastic = 0;
-DCM_EN.options.nograph    = 1;
-% mean-centering of regressors
-% Importantly, this option is set differently in default SPM8 (TRUE) and
-% SPM12 (FALSE)
-DCM_EN.options.centre     = 1;
-
-DCM_EN.Y.dt    = SPM.xY.RT;
-DCM_EN.U.dt    = SPM.Sess.U(1).dt;
-DCM_EN.U.name  = [SPM.Sess.U(1).name];
-DCM_EN.U.u     = [SPM.Sess.U(1).u(33:end,1)];  %SPM, 1 = 'Cond'; 2 = 'Bas';
-DCM_EN.TE      = 0.03;
-DCM_EN.n       = 3; % number of ROIs in a single DCM model
-DCM_EN.delays  = repmat(SPM.xY.RT,DCM_EN.n,1);
-DCM_EN.d       = zeros(DCM_EN.n,DCM_EN.n,0);
-DCM_EN.Y.X0    = []; % intializing regressors for DCM model
-
+    % Function to prepare initial DCM structure from parameters coded in the 
+    % protocol JSON file and the SPM structure.
+    
+    % input:
+    % SPM - SPM structure
+    %
+    % output:
+    % DCM_EN    - initial DCM structure
+    % dcmParTag - model-defining structure for a target model (model 1)
+    % dcmParOpp - model-defining structure for an opposed model (model 2)
+    %
+    % Written by Yury Koush, adapted by Moritz Gruber.
+    % -------------------------------------------------------------------------
+    
+    % -- Get P struct from workspace ------------------------------------------
+    jsonfile = evalin('base', 'P.ProtocolFile');
+    
+    % -- Load DCM specification from JSON file --------------------------------
+    dcmDef = parseDCMdef(jsonfile);
+    
+    dcmParTag.tdcmName = ['DCM_MTag_' date];
+    dcmParTag.dcm      = dcmDef.target;
+    
+    dcmParOpp.tdcmName = ['DCM_MOpp_' date];
+    dcmParOpp.dcm      = dcmDef.opposed;
+    
+    DCM_EN.options     = dcmDef.options;
+    
+    % -- Fill DCM_EN based on SPM ---------------------------------------------
+    
+    % Adapt this for multiple inputs eventually
+    DCM_EN.Y.dt     = SPM.xY.RT;
+    DCM_EN.U.dt     = SPM.Sess.U(1).dt;
+    DCM_EN.U.name   = SPM.Sess.U(1).name;
+    DCM_EN.U.u      = SPM.Sess.U(1).u(33:end,1);  %SPM, 1 = 'Cond'; 2 = 'Bas';
+    DCM_EN.TE       = 0.03;
+    DCM_EN.n        = length(dcmDef.target.a); % number of ROIs in a single DCM model
+    DCM_EN.delays   = repmat(SPM.xY.RT,DCM_EN.n,1);
+    DCM_EN.d        = zeros(DCM_EN.n,DCM_EN.n,0);
+    DCM_EN.Y.X0     = []; % intializing regressors for DCM model
+    DCM_EN.roiNames = dcmDef.roiNames;
+    
+    end

--- a/opennft/matlab/utils/loadProtocolData.m
+++ b/opennft/matlab/utils/loadProtocolData.m
@@ -133,7 +133,12 @@ if strcmp(P.Prot, 'Cont') && isSVM
     end
 end
 
-P.Protocol = rmfield(prt,'dcmdef');  % to avoid unsupported file type error in python
+% -- remove dcmdef field -- %
+if isDCM 
+    prt = rmfield(prt, 'dcmdef');
+end
+    
+P.Protocol = prt;
 assignin('base', 'P', P);
 end
 

--- a/opennft/matlab/utils/loadProtocolData.m
+++ b/opennft/matlab/utils/loadProtocolData.m
@@ -133,7 +133,7 @@ if strcmp(P.Prot, 'Cont') && isSVM
     end
 end
 
-P.Protocol = prt;
+P.Protocol = rmfield(prt,'dcmdef');  % to avoid unsupported file type error in python
 assignin('base', 'P', P);
 end
 

--- a/opennft/matlab/utils/parseDCMdef.m
+++ b/opennft/matlab/utils/parseDCMdef.m
@@ -1,0 +1,241 @@
+function out = parseDCMdef(jsonfile)
+% usage DCM = parseDCMdef(jsonfile)
+% 
+% Takes in the protocol JSON file, parses the a,b,c,d arrays that
+% specify the DCM topology and returns the DCM struct.
+%
+% EXPECTS: jsonfile {str} ..... path to JSON file containing a field named
+%                               "dcmdef" containing target and opposed model
+%                               definitions, roiNames and options 
+%                               (see example below)
+%
+% RETURNS: out {struct} ....... with fields 'target' and 'opposed', which 
+%                               are structs containing a,b,c,d fields and
+%                               'roiNames' and 'options' 
+%                               (see example below)
+%
+% For information % on how a,b,c,d matrices encode topology, please consult 
+% DCM literature, e.g.,
+% 
+%   Stephan KE, Kasper L, Harrison LM, et al., Nonlinear dynamic causal 
+%   models for fMRI, Neuroimage 2008;42(2):649–662.
+% 
+%   K.J. Friston et al., Dynamic Causal Modeling,
+%   NeuroImage 2003;19:1273–1302
+%
+%           ------------------------------------------------------
+%
+% Here is an example JSON definition of a set of two two-region DCMs.
+% 
+%   
+%     {
+%         "dcmdef": {
+% 
+%             "target": {
+% 
+%             "a": [[1, 0], 
+%                   [0,1]],
+% 
+%             "b": [[[0,0],
+%                    [0,0]],
+%                   [[1,1],
+%                    [1,1]]],            
+% 
+%             "c": [1,1],
+% 
+%             "d": []
+%                      },
+% 
+%             "opposed": {
+% 
+%                 "a": [[1, 1], 
+%                       [1,1]],
+% 
+%                 "b": [[[1,1],
+%                        [1,1]],
+%                       [[0,0],
+%                        [0,0]]],            
+% 
+%                 "c": [1,0],
+% 
+%                 "d": []
+%                     },
+% 
+%             "roiNames": ["L-SMA", "Precentral-G"],
+%
+%             "options": {
+%                 "nonlinear": 0,
+%                 "two_state": 0,
+%                 "stochastic": 0,
+%                 "nograph": 1,
+%                 "centre": 1
+%             }
+% 
+%          }
+%     }
+%
+% This example JSON file will produce the following output:
+% 
+% out = 
+% 
+%   struct with fields:
+% 
+%      target: [1×1 struct]
+%     opposed: [1×1 struct]
+%    roiNames: {["L-SMA"]  ["Precentral-G"]}
+%     options: [1x1 struct]
+%
+% Both structs contain a,b,c,d matrices as fields. If you wish, you can run
+% the function on the example JSON above to inspect the fields further.
+%
+% Note: This function requires 'loadjson', which is part of the JSONLab 
+% toolbox (http://iso2mesh.sf.net/cgi-bin/index.cgi?jsonlab).
+%
+%
+% Moritz Gruber, SNS Lab, May 2019
+% -------------------------------------------------------------------------
+
+% -- Load json file -------------------------------------------------------
+try
+    in = loadjson(jsonfile);
+catch
+    error('Invalid json file')
+end
+
+% -- Get options if specified ---------------------------------------------
+try 
+    out.options = in.dcmdef.options;
+catch
+    out.options = makeDefaultOptions();
+end
+
+% -- Extract model definition of target and opposed model -----------------
+
+for model = {'target','opposed'}
+    
+    fprintf('Parsing %s model definition...\n',model{:})
+    
+    % -- Get ABCD fields --------------------------------------------------
+    try 
+        dcmdefRaw = in.dcmdef.(model{:});
+    catch
+        error(['The JSON file does not contain a field called dcmdef.%s. ' ...
+               'Please consult the docstring for input format.'],model{:})
+    end
+
+    % -- Check for completeness and make fieldnames lower case -- %
+    dcmdefRaw = makeFieldnamesLowercase(dcmdefRaw);
+
+    fnamesSorted = fieldnames(dcmdefRaw);
+
+    for fn = {'a','b','c'}
+
+        if ~contains(fn,fnamesSorted)
+            error('Field "%s" not specified.', fn{:})
+        end   
+
+    end
+
+    % -- Get and check dimensions -----------------------------------------
+
+    nRegions = length(dcmdefRaw.a);
+    nInputs  = max(size(dcmdefRaw.c));
+
+    % -- Reshape b correctly -- %
+    if iscell(dcmdefRaw.b) % 3-d arrays in JSON become cell arrays here
+
+        try
+            DCM.b = reshape(cell2mat(dcmdefRaw.b)',nRegions,nRegions,nInputs);
+        catch
+            error('DCM.b could not be reshaped. Please verify dimensions')
+        end
+
+    elseif isequal(size(dcmdefRaw.b), [nRegions nRegions])
+
+        DCM.b = dcmdefRaw.b;
+
+    else
+
+        error('"b" has incorrect dimensions.')
+
+    end
+    
+    if out.options.nonlinear
+
+        % -- Reshape d correctly -- %
+        if ~isempty(dcmdefRaw.d)
+
+            if iscell(dcmdefRaw.d) % 3-d arrays in JSON become cell arrays here
+
+                try
+                    DCM.d = reshape(cell2mat(dcmdefRaw.d)',nRegions,nRegions,nRegions);
+                catch
+                    error('DCM.d could not be reshaped. Please verify dimensions.')
+                end
+
+            elseif isequal(size(dcmdefRaw.d), [nRegions nRegions])
+
+                DCM.d = dcmdefRaw.d;
+
+            end
+        end
+    end
+
+    % -- Finish building output struct ------------------------------------
+    DCM.a = dcmdefRaw.a;
+    DCM.c = dcmdefRaw.c';
+    
+    % -- Pack up ----------------------------------------------------------
+    out.(model{:}) = sortFieldnames(DCM);
+
+end
+
+% -- Get ROI names if specified -------------------------------------------
+
+try 
+    out.roiNames = in.dcmdef.roiNames;
+catch
+    warning('No ROI names specified. Creating default names.')
+    out.roiNames = makeDefaultRoiNames(nRegions);
+end
+
+end
+
+% =========================== AUXILIARIES =================================
+
+function outstruct = makeFieldnamesLowercase(instruct)
+
+for fx = fieldnames(instruct)'
+    outstruct.(lower(fx{:})) = instruct.(fx{:});   
+end
+
+end
+
+function outstruct = sortFieldnames(instruct)
+% Sorts the fieldnames of the input struct alphabetically.
+
+fnamesSorted = sort(fieldnames(instruct));
+
+for fx = 1:length(fnamesSorted)
+    outstruct.(fnamesSorted{fx}) = instruct.(fnamesSorted{fx});
+end
+
+end
+
+function roiNames = makeDefaultRoiNames(nRegions)
+% Returns a cell array {'ROI-1',...,'ROI-N'} where N is the number of ROIs.
+
+roiNames = {};
+for roi = 1:nRegions
+    roiNames{end+1} = ['ROI-' num2str(roi)];
+end
+
+end
+
+function options = makeDefaultOptions()
+% Consult DCM or SPM documentation for an explanation of those fields. 
+options.two_state  = 0;
+options.stochastic = 0;
+options.nograph    = 1;
+options.centre     = 1;
+end


### PR DESCRIPTION
Hi all!
 
I incorporated the DCM definition process into the protocol JSON file, as we (SNS lab) are internally trying to minimize the number of experiment-specific files/scripts one needs to modify for each experiment. Here, 

* I incorporated the DCM definition into the protocol JSON file by adding a new key: `dcmdef`. This includes target and opposed model topology, options and ROI names. 
* created `parseDCMdef.m`, a function that extracts the DCM definition from the JSON file and returns the DCM fields
* Adapted `dcmPrep.m` to read from the protocol file and set the DCM definitions accordingly
* Adapted `dcmBegin.m` to dynamically depend on dcmPrep (no longer requiring manual modification)
* Made a minor change to `loadProtocolData.m` to remove the newly introduced JSON field from the `P` struct so as not to cause data type errors in python

In my tests, this version yielded the exact same feedback values as the default implementation. 

Perhaps this is something you might be interested in incorporating. 