### PR TITLE
Setup codespell

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -8,3 +8,7 @@ setup_requires =
 # W503: line break before binary operator
 ignore=W503
 max-line-length = 120
+
+[codespell]
+skip = ./.git
+ignore-words-list = te


### PR DESCRIPTION
Currently the only false positive is `TE`.