### PR TITLE
Flake8: fix more errors

### DIFF
--- a/install_matlabengine.py
+++ b/install_matlabengine.py
@@ -6,8 +6,8 @@ import subprocess
 
 sys.path = sys.argv[3:]
 
-import elevate
-import chardet
+import elevate  # noqa: E402
+import chardet  # noqa: E402
 
 
 def main():

--- a/opennft/mrpulse.py
+++ b/opennft/mrpulse.py
@@ -48,28 +48,27 @@ def keypressed(event):
     global pulses
     global displayEvent
     if event.Ascii == 13:
-        keys='<ENTER>'
+        keys = '<ENTER>'
     elif event.Ascii == 8:
-        keys='<BACK SPACE>'
+        keys = '<BACK SPACE>'
     elif event.Ascii == 9:
-        keys='<TAB>'
+        keys = '<TAB>'
         np_arr = toNpData(pulses)
         #counter = np_arr[0]
         #counter += 1
         #tmp = np_arr[counter]
         #np_arr[counter] = counter + 1
         #np_arr[counter] = tmp
-
         logger.debug('arr {}', np_arr)
-    elif event.Ascii == 35:  # 'ASCII character '#'
+    elif event.Ascii == 35:
+        keys = '#'
         recordPulseEvent()
         #displayEvent.set()
-
     elif event.Ascii == 27:
+        keys = '<ESC>'
         np_arr = toNpData(pulses)
         logger.debug('pulses {}', pulses)
         logger.debug('arr', np_arr)
-        keys='<ESC>'
         sys.exit(0)
     else:
         #keys = chr(event.Ascii)

--- a/opennft/mrpulse.py
+++ b/opennft/mrpulse.py
@@ -61,7 +61,7 @@ def keypressed(event):
         #np_arr[counter] = tmp
 
         logger.debug('arr {}', np_arr)
-    elif event.Ascii == 35:  # it is # sign
+    elif event.Ascii == 35:  # 'ASCII character '#'
         recordPulseEvent()
         #displayEvent.set()
 

--- a/opennft/opennft.py
+++ b/opennft/opennft.py
@@ -2422,7 +2422,7 @@ class OpenNFT(QWidget):
         # matlabStatusTimer
 
         mgr = multiprocessing.Manager()
-        ns = mgr.Namespace()
+        # ns = mgr.Namespace()
         # ns.ptb = self.ptbScreen
         self.displayData = {'feedbackType': 'DCM', 'condition': 2.0, 'dispValue': 0.0, 'Reward': ''}
         # self.ptbScreen.display(displayData)

--- a/opennft/opennft.py
+++ b/opennft/opennft.py
@@ -686,8 +686,8 @@ class OpenNFT(QWidget):
                     # self.udpSender.send_data(self.displayData['instrValue'])
 
         if self.cbUseTCPData.isChecked():
-            fname = str(Path(self.P['WatchFolder']) /
-                                 self.P['FirstFileNameTxt'].replace('Image Series No','ImgSerNr').replace('#','iter').format(**(self.P),iter=self.iteration))
+            fname = str(Path(self.P['WatchFolder'])
+                        / self.P['FirstFileNameTxt'].replace('Image Series No','ImgSerNr').replace('#','iter').format(**(self.P),iter=self.iteration))
         else:
             try:
                 fname = self.files_queue.get_nowait()

--- a/opennft/plugins/onp_roiiglm.py
+++ b/opennft/plugins/onp_roiiglm.py
@@ -26,7 +26,7 @@ Written by Tibor Auer
 
 """
 
-from pyniexp.mlplugins import dataProcess, SIG_NOTSTARTED, SIG_RUNNING, SIG_STOPPED, SIG_NEWIMAGE
+from pyniexp.mlplugins import dataProcess
 from loguru import logger
 from multiprocessing import Value, RawArray
 from numpy import array, savetxt

--- a/opennft/plugins/onp_roiswglm.py
+++ b/opennft/plugins/onp_roiswglm.py
@@ -27,7 +27,7 @@ Written by Tibor Auer
 
 """
 
-from pyniexp.mlplugins import dataProcess, SIG_NOTSTARTED, SIG_RUNNING, SIG_STOPPED, SIG_NEWIMAGE
+from pyniexp.mlplugins import dataProcess
 from loguru import logger
 from multiprocessing import Value, RawArray
 from numpy import array, meshgrid, savetxt

--- a/opennft/rtqa_fdm.py
+++ b/opennft/rtqa_fdm.py
@@ -61,20 +61,20 @@ class FD:
             self.meanFD = 0
 
         if self.FD[i] >= self.threshold[1]:
-           self.excFD[0] += 1
+            self.excFD[0] += 1
 
-           if self.excFDIndexes_1[-1] == -1:
-               self.excFDIndexes_1 = np.array([i - 1])
-           else:
-               self.excFDIndexes_1 = np.append(self.excFDIndexes_1, i - 1)
+            if self.excFDIndexes_1[-1] == -1:
+                self.excFDIndexes_1 = np.array([i - 1])
+            else:
+                self.excFDIndexes_1 = np.append(self.excFDIndexes_1, i - 1)
 
-           if self.FD[i] >= self.threshold[2]:
-              self.excFD[1] += 1
+            if self.FD[i] >= self.threshold[2]:
+                self.excFD[1] += 1
 
-              if self.excFDIndexes_2[-1] == -1:
-                  self.excFDIndexes_2 = np.array([i - 1])
-              else:
-                  self.excFDIndexes_2 = np.append(self.excFDIndexes_2, i - 1)
+                if self.excFDIndexes_2[-1] == -1:
+                    self.excFDIndexes_2 = np.array([i - 1])
+                else:
+                    self.excFDIndexes_2 = np.append(self.excFDIndexes_2, i - 1)
 
     def micro_displacement(self):
 

--- a/opennft/rtqa_fdm.py
+++ b/opennft/rtqa_fdm.py
@@ -7,7 +7,7 @@ import opennft.config as c
 
 
 class FD:
-    def __init__(self, xmax, module = None):
+    def __init__(self, xmax, module=None):
         self.module = module
 
         # names of the dofs


### PR DESCRIPTION
Partially fixes #133.

I have left some errors for later:
```
E116 unexpected indentation (comment)
E126 continuation line over-indented for hanging indent
E226 missing whitespace around arithmetic operator
E231 missing whitespace after ','
E265 block comment should start with '#`'
E501 line too long
E741 ambiguous variable name 'l'
F401 'opennft.__version__.__version__' imported but unused
```