### PR TITLE
Use subprocess.run() instead of run()

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,6 @@ from distutils.core import DistutilsOptionError
 from setuptools import setup, find_packages
 from setuptools.command.install import install
 from setuptools.command.develop import develop
-from subprocess import run
 
 
 NAME = 'OpenNFT'
@@ -140,7 +139,7 @@ class InstallMatlabEngineMixin:
 class InstallGitSubmodulesMixin:
     def _install_git_submodules(self):
         if pathlib.Path('.git').exists():
-            run(['git', 'submodule', 'update', '--init', '--recursive'])
+            subprocess.run(['git', 'submodule', 'update', '--init', '--recursive'])
 
 
 class InstallCommand(install, InstallMatlabEngineMixin, InstallGitSubmodulesMixin):


### PR DESCRIPTION
Rationale:

1. Silence this LGTM.com alert:
Module '`subprocess`' is imported with both '`import`' and '`import from`'
https://lgtm.com/projects/g/OpenNFT/OpenNFT/snapshot/0d54f6789d902a90e2b8bf13c1252c3b56dba710/files/setup.py?sort=name&dir=ASC&mode=heatmap#xc494989fb6a7d9e7:1

2. Calling both [`subprocess.run()`](https://github.com/OpenNFT/OpenNFT/blob/29bf02cb79477c54b8d6a3c14791c2808a9434c5/setup.py#L120) and [`run()`](https://github.com/OpenNFT/OpenNFT/blob/29bf02cb79477c54b8d6a3c14791c2808a9434c5/setup.py#L143) in the same file is inconsistent.

3. This script also defines `run()` methods in two classes, so use the full name to avoid any confusion.