### PR TITLE
Use of `global` at module level

### DIFF
--- a/opennft/mrpulse.py
+++ b/opennft/mrpulse.py
@@ -20,9 +20,9 @@ import multiprocessing as mp
 import numpy as np
 from opennft.eventrecorder import Times
 
-global pulses
-global displayEvent
-global recorder
+pulses = None
+displayEvent = None
+recorder = None
 
 
 def toNpData(mp_arr):


### PR DESCRIPTION
Declaring variables as global at module-level is redundant. Initialize them instead.

Silence these LGTM.com warnings:
https://lgtm.com/projects/g/OpenNFT/OpenNFT/alerts/?severity=warning