### PR TITLE
Some fixes, hopefully, for DCM feedback errors found on test data

### DIFF
--- a/opennft/matlab/nfbCalc.m
+++ b/opennft/matlab/nfbCalc.m
@@ -257,7 +257,7 @@ if flags.isDCM
         mainLoopData.vectNFBs(indNFTrial) = logBF;
         mainLoopData.flagEndDCM = 1;
         tmp_fbVal = mainLoopData.logBF(indNFTrial);
-        dispValue = round(P.MaxFeedbackVal*tmp_fbVal, P.FeedbackValDec);
+        mainLoopData.dispValue = round(P.MaxFeedbackVal*tmp_fbVal, P.FeedbackValDec);
 
         % calculating monetory reward value
         if mainLoopData.dispValue > thReward

--- a/opennft/opennft.py
+++ b/opennft/opennft.py
@@ -441,6 +441,8 @@ class OpenNFT(QWidget):
         self.call_timer.timeout.connect(self.callMainLoopIteration)
         self.orthViewUpdateCheckTimer.timeout.connect(self.onCheckOrthViewUpdated)
 
+        self.cbType.currentTextChanged.connect(self.onChangeFBType)
+
         self.cbDataType.currentTextChanged.connect(self.onChangeDataType)
         self.onChangeDataType()
 
@@ -472,6 +474,13 @@ class OpenNFT(QWidget):
         self.onChangePosMapVisible()
         self.onChangeNegMapVisible()
         self.onChangeUseUDPFeedback()
+
+    def onChangeFBType(self, value):
+        if value=='DCM':
+            self.cbFeedbackPlot.setChecked(False)
+            self.cbFeedbackPlot.setEnabled(False)
+        else:
+            self.cbFeedbackPlot.setEnabled(True)
 
     # --------------------------------------------------------------------------
     def onChangePosMapVisible(self):
@@ -912,8 +921,8 @@ class OpenNFT(QWidget):
             if config.USE_UDP_FEEDBACK:
                 logger.info('Sending by UDP - dispValue = {}', self.displayData['dispValue'])
                 self.udpSender.send_data(self.displayData['dispValue'])
-            if self.P['Type'] != 'DCM' or int(self.eng.evalin('base', 'mainLoopData.flagEndDCM')) == 0:
-                self.displaySamples.append(self.displayData['dispValue'])
+
+            self.displaySamples.append(self.displayData['dispValue'])
 
         # main logic end
 
@@ -2676,7 +2685,7 @@ class OpenNFT(QWidget):
         dataRaw = np.array(self.outputSamples[key], ndmin=2)[self.selectedRoi,:]
         dataProc = np.array(self.outputSamples['kalmanProcTimeSeries'], ndmin=2)[self.selectedRoi,:]
         dataNorm = np.array(self.outputSamples['scalProcTimeSeries'], ndmin=2)[self.selectedRoi,:]
-        if self.P['PlotFeedback']:
+        if self.P['PlotFeedback'] and self.P['Type'] != 'DCM':
             dataNorm = np.concatenate(
                 (dataNorm, np.array([self.displaySamples]) / self.P['MaxFeedbackVal'])
             )

--- a/opennft/opennft.py
+++ b/opennft/opennft.py
@@ -912,7 +912,8 @@ class OpenNFT(QWidget):
             if config.USE_UDP_FEEDBACK:
                 logger.info('Sending by UDP - dispValue = {}', self.displayData['dispValue'])
                 self.udpSender.send_data(self.displayData['dispValue'])
-            self.displaySamples.append(self.displayData['dispValue'])
+            if self.P['Type'] != 'DCM' or int(self.eng.evalin('base', 'mainLoopData.flagEndDCM')) == 0:
+                self.displaySamples.append(self.displayData['dispValue'])
 
         # main logic end
 

--- a/opennft/opennft.py
+++ b/opennft/opennft.py
@@ -2686,7 +2686,7 @@ class OpenNFT(QWidget):
         dataRaw = np.array(self.outputSamples[key], ndmin=2)[self.selectedRoi,:]
         dataProc = np.array(self.outputSamples['kalmanProcTimeSeries'], ndmin=2)[self.selectedRoi,:]
         dataNorm = np.array(self.outputSamples['scalProcTimeSeries'], ndmin=2)[self.selectedRoi,:]
-        if self.P['PlotFeedback'] and self.P['Type'] != 'DCM':
+        if self.P['PlotFeedback']:
             dataNorm = np.concatenate(
                 (dataNorm, np.array([self.displaySamples]) / self.P['MaxFeedbackVal'])
             )

--- a/opennft/opennft.py
+++ b/opennft/opennft.py
@@ -475,6 +475,7 @@ class OpenNFT(QWidget):
         self.onChangeNegMapVisible()
         self.onChangeUseUDPFeedback()
 
+    # --------------------------------------------------------------------------
     def onChangeFBType(self, value):
         if value=='DCM':
             self.cbFeedbackPlot.setChecked(False)


### PR DESCRIPTION
When testing on DCM dataset the following issue happens on ~scan 161, after the first FB session is evaluated

(here I emulated online session by copying files one by one every TR s, to exclude possible offline mode issues; so the output somewhat differs from offline mode)

```
2022-03-15 07:35:05 | INFO      | opennft:callMainLoopIteration - Call iteration for file "001_000008_000161.dcm"
TIMING: 5 iter - PREPROC MC: 2.534752e-01 s - SMOOTH: 2.042950e-02 s - IGLM: 5.246740e-02 s
2022-03-15 07:35:06 | INFO      | opennft:callMainLoopIteration -   preprocess fMRI Volume: 0.36 s
2022-03-15 07:35:06 | INFO      | opennft:callMainLoopIteration -   preprocess signal: 17.00 ms
2022-03-15 07:35:06 | INFO      | opennft:callMainLoopIteration - Sending by UDP - dispValue = 0.0
2022-03-15 07:35:06 | INFO      | opennft:displayMosaicImage - Getting background volume: 7.00 ms
2022-03-15 07:35:06 | INFO      | opennft:callMainLoopIteration - Display mosaic image: 22.00 ms
Traceback (most recent call last):
  File "opennft-venv\lib\site-packages\opennft\opennft.py", line 978, in callMainLoopIteration
    self.drawRoiPlots(init)
  File "opennft-venv\lib\site-packages\opennft\opennft.py", line 2685, in drawRoiPlots
    (dataNorm, np.array([self.displaySamples]) / self.P['MaxFeedbackVal'])
  File "opennft-venv\lib\site-packages\pyqtgraph\numpy_fix.py", line 13, in concatenate
    return np.concatenate_orig(vals, *args, **kwds)
  File "<__array_function__ internals>", line 6, in concatenate
ValueError: all the input array dimensions for the concatenation axis must match exactly, but along dimension 1, the array at index 0 has size 109 and the array at index 1 has size 151
```

So at the time the shapes of arrays are:
```
dataNorm.shape:
(3, 109)
np.array([self.displaySamples]).shape
(1, 151)
```

The first commit of this PR seems to solve the issue, however I am not fully sure this is the proper way of doing that.

Also the second commit is about feedback always being 0, but that is a much clearer issue or at least I think it is.

If the issue should not be hapening anyway, and is the result of local setup and not OpenNFT, please let me know, in any case feedback is apreciated