### PR TITLE
Add conditional check to fix bug when using PollingObserver

### DIFF
--- a/opennft/opennft.py
+++ b/opennft/opennft.py
@@ -1133,7 +1133,11 @@ class OpenNFT(QWidget):
         event_handler = CreateFileEventHandler(
             searchString, self.files_queue, self.recorder)
 
-        self.fs_observer = Observer()
+        if config.USE_POLLING_FS_OBSERVER:
+            self.fs_observer = PollingObserver()
+        else:
+            self.fs_observer = Observer()
+
         self.fs_observer.schedule(
             event_handler, str(path), recursive=True)
 


### PR DESCRIPTION
This PR addresses a bug that arises when the user specifies `USE_POLLING_OBSERVER = True` in `config.py`. Line 1136 was instantiating the class `Observer()` instead of `PollingObserver()`. I added a conditional check of the config on new lines 1136-1140 to use the appropriate class and have confirmed it works for our lab's use cases. Related to issue #156 